### PR TITLE
Improve subtext contrast against animated blobs

### DIFF
--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -48,24 +48,26 @@ h2 {
     margin: 0;
     padding: 0;
     font-weight: 300;
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(255, 255, 255, 0.85);
     letter-spacing: 0.25em;
     text-transform: uppercase;
     line-height: 1.2;
     font-size: 0.75rem;
     margin-top: 1.2rem;
+    text-shadow: 0 0 24px rgba(3, 20, 45, 0.9), 0 1px 6px rgba(0, 0, 0, 0.6);
     opacity: 0;
     transform: translateY(16px);
     animation: fadeUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.3s forwards;
 }
 
 .intro-text {
-    color: rgba(255, 255, 255, 0.45);
+    color: rgba(255, 255, 255, 0.65);
     font-size: 0.8rem;
     font-weight: 400;
     letter-spacing: 0.06em;
     margin-top: 1.6rem;
     text-align: center;
+    text-shadow: 0 0 24px rgba(3, 20, 45, 0.9), 0 1px 6px rgba(0, 0, 0, 0.6);
     opacity: 0;
     transform: translateY(12px);
     animation: fadeUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.5s forwards;


### PR DESCRIPTION
Bump h2 and intro-text opacity and add dark text-shadow halo so subtitles remain legible when bright teal/green blobs animate behind them on mobile.